### PR TITLE
API Improvements

### DIFF
--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -9,34 +9,19 @@ package com.timgroup.statsd;
  */
 public final class NoOpStatsDClient implements StatsDClient {
     @Override public void stop() { }
-    @Override public void count(String aspect, int delta, String[] tags) { }
-    @Override public void count(String aspect, int delta) { }
-    @Override public void incrementCounter(String aspect, String[] tags) { }
-    @Override public void incrementCounter(String aspect) { }
-    @Override public void increment(String aspect, String[] tags) { }
-    @Override public void increment(String aspect) { }
-    @Override public void decrementCounter(String aspect, String[] tags) { }
-    @Override public void decrementCounter(String aspect) { }
-    @Override public void decrement(String aspect, String[] tags) { }
-    @Override public void decrement(String aspect) { }
-    @Override public void recordGaugeValue(String aspect, double value, String[] tags) { }
-    @Override public void recordGaugeValue(String aspect, double value) { }
-    @Override public void gauge(String aspect, double value, String[] tags) { }
-    @Override public void gauge(String aspect, double value) { }
-    @Override public void recordGaugeValue(String aspect, int value, String[] tags) { }
-    @Override public void recordGaugeValue(String aspect, int value) { }
-    @Override public void gauge(String aspect, int value, String[] tags) { }
-    @Override public void gauge(String aspect, int value) { }
-    @Override public void recordExecutionTime(String aspect, int timeInMs, String[] tags) { }
-    @Override public void recordExecutionTime(String aspect, int timeInMs) { }
-    @Override public void time(String aspect, int value, String[] tags) { }
-    @Override public void time(String aspect, int value) { }
-    @Override public void recordHistogramValue(String aspect, double value, String[] tags) { }
-    @Override public void recordHistogramValue(String aspect, double value) { }
-    @Override public void histogram(String aspect, double value, String[] tags) { }
-    @Override public void histogram(String aspect, double value) { }
-    @Override public void recordHistogramValue(String aspect, int value, String[] tags) { }
-    @Override public void recordHistogramValue(String aspect, int value) { }
-    @Override public void histogram(String aspect, int value, String[] tags) { }
-    @Override public void histogram(String aspect, int value) { }
+    @Override public void count(String aspect, int delta, String... tags) { }
+    @Override public void incrementCounter(String aspect, String... tags) { }
+    @Override public void increment(String aspect, String... tags) { }
+    @Override public void decrementCounter(String aspect, String... tags) { }
+    @Override public void decrement(String aspect, String... tags) { }
+    @Override public void recordGaugeValue(String aspect, double value, String... tags) { }
+    @Override public void gauge(String aspect, double value, String... tags) { }
+    @Override public void recordGaugeValue(String aspect, int value, String... tags) { }
+    @Override public void gauge(String aspect, int value, String... tags) { }
+    @Override public void recordExecutionTime(String aspect, long timeInMs, String... tags) { }
+    @Override public void time(String aspect, long value, String... tags) { }
+    @Override public void recordHistogramValue(String aspect, double value, String... tags) { }
+    @Override public void histogram(String aspect, double value, String... tags) { }
+    @Override public void recordHistogramValue(String aspect, int value, String... tags) { }
+    @Override public void histogram(String aspect, int value, String... tags) { }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -173,23 +173,8 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void count(String aspect, int delta, String[] tags) {
+    public void count(String aspect, int delta, String... tags) {
         send(String.format("%s%s:%d|c%s", prefix, aspect, delta, tagString(tags)));
-    }
-
-    /**
-     * Adjusts the specified counter by a given delta.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to adjust
-     * @param delta
-     *     the amount to adjust the counter by
-     */
-    @Override
-    public void count(String aspect, int delta) {
-        send(String.format("%s%s:%d|c", prefix, aspect, delta));
     }
 
     /**
@@ -203,37 +188,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void incrementCounter(String aspect, String[] tags) {
+    public void incrementCounter(String aspect, String... tags) {
         count(aspect, 1, tags);
-    }
-
-    /**
-     * Increments the specified counter by one.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to increment
-     */
-    @Override
-    public void incrementCounter(String aspect) {
-        count(aspect, 1);
     }
 
     /**
      * Convenience method equivalent to {@link #incrementCounter(String, String[])}. 
      */
     @Override
-    public void increment(String aspect, String[] tags) {
+    public void increment(String aspect, String... tags) {
         incrementCounter(aspect, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #incrementCounter(String)}. 
-     */
-    @Override
-    public void increment(String aspect) {
-        incrementCounter(aspect);
     }
 
     /**
@@ -247,37 +211,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void decrementCounter(String aspect, String[] tags) {
+    public void decrementCounter(String aspect, String... tags) {
         count(aspect, -1, tags);
-    }
-
-    /**
-     * Decrements the specified counter by one.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to decrement
-     */
-    @Override
-    public void decrementCounter(String aspect) {
-        count(aspect, -1);
     }
 
     /**
      * Convenience method equivalent to {@link #decrementCounter(String, String[])}. 
      */
     @Override
-    public void decrement(String aspect, String[] tags) {
+    public void decrement(String aspect, String... tags) {
         decrementCounter(aspect, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #decrementCounter(String)}. 
-     */
-    @Override
-    public void decrement(String aspect) {
-        decrementCounter(aspect);
     }
 
     /**
@@ -293,43 +236,18 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void recordGaugeValue(String aspect, double value, String[] tags) {
+    public void recordGaugeValue(String aspect, double value, String... tags) {
         /* Intentionally using %s rather than %f here to avoid
          * padding with extra 0s to represent precision */
         send(String.format("%s%s:%s|g%s", prefix, aspect, FORMAT.format(value), tagString(tags)));
     }
 
     /**
-     * Records the latest fixed value for the specified named gauge.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     */
-    @Override
-    public void recordGaugeValue(String aspect, double value) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        send(String.format("%s%s:%s|g", prefix, aspect, FORMAT.format(value)));
-    }
-
-    /**
      * Convenience method equivalent to {@link #recordGaugeValue(String, double, String[])}.
      */
     @Override
-    public void gauge(String aspect, double value, String[] tags) {
+    public void gauge(String aspect, double value, String... tags) {
         recordGaugeValue(aspect, value, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, double)}.
-     */
-    @Override
-    public void gauge(String aspect, double value) {
-        recordGaugeValue(aspect, value);
     }
 
 
@@ -346,39 +264,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void recordGaugeValue(String aspect, int value, String[] tags) {
+    public void recordGaugeValue(String aspect, int value, String... tags) {
         send(String.format("%s%s:%d|g%s", prefix, aspect, value, tagString(tags)));
-    }
-
-    /**
-     * Records the latest fixed value for the specified named gauge.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     */
-    @Override
-    public void recordGaugeValue(String aspect, int value) {
-        send(String.format("%s%s:%d|g", prefix, aspect, value));
     }
 
     /**
      * Convenience method equivalent to {@link #recordGaugeValue(String, int, String[])}. 
      */
     @Override
-    public void gauge(String aspect, int value, String[] tags) {
+    public void gauge(String aspect, int value, String... tags) {
         recordGaugeValue(aspect, value, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, int)}. 
-     */
-    @Override
-    public void gauge(String aspect, int value) {
-        recordGaugeValue(aspect, value);
     }
 
     /**
@@ -394,39 +289,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void recordExecutionTime(String aspect, int timeInMs, String[] tags) {
+    public void recordExecutionTime(String aspect, long timeInMs, String... tags) {
         send(String.format("%s%s:%d|ms%s", prefix, aspect, timeInMs, tagString(tags)));
     }
 
     /**
-     * Records an execution time in milliseconds for the specified named operation.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the timed operation
-     * @param timeInMs
-     *     the time in milliseconds
+     * Convenience method equivalent to {@link #recordExecutionTime(String, long, String[])}.
      */
     @Override
-    public void recordExecutionTime(String aspect, int timeInMs) {
-        send(String.format("%s%s:%d|ms", prefix, aspect, timeInMs));
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, int, String[])}. 
-     */
-    @Override
-    public void time(String aspect, int value, String[] tags) {
+    public void time(String aspect, long value, String... tags) {
         recordExecutionTime(aspect, value, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, int)}. 
-     */
-    @Override
-    public void time(String aspect, int value) {
-        recordExecutionTime(aspect, value);
     }
 
     /**
@@ -442,43 +314,18 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void recordHistogramValue(String aspect, double value, String[] tags) {
+    public void recordHistogramValue(String aspect, double value, String... tags) {
         /* Intentionally using %s rather than %f here to avoid
          * padding with extra 0s to represent precision */
         send(String.format("%s%s:%s|h%s", prefix, aspect, FORMAT.format(value), tagString(tags)));
     }
 
     /**
-     * Records a value for the specified named histogram.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     */
-    @Override
-    public void recordHistogramValue(String aspect, double value) {
-        /* Intentionally using %s rather than %f here to avoid
-         * padding with extra 0s to represent precision */
-        send(String.format("%s%s:%s|h", prefix, aspect, FORMAT.format(value)));
-    }
-
-    /**
      * Convenience method equivalent to {@link #recordHistogramValue(String, double, String[])}.
      */
     @Override
-    public void histogram(String aspect, double value, String[] tags) {
+    public void histogram(String aspect, double value, String... tags) {
         recordHistogramValue(aspect, value, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, double, String[])}.
-     */
-    @Override
-    public void histogram(String aspect, double value) {
-        recordHistogramValue(aspect, value);
     }
 
     /**
@@ -494,39 +341,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      *     array of tags to be added to the data
      */
     @Override
-    public void recordHistogramValue(String aspect, int value, String[] tags) {
+    public void recordHistogramValue(String aspect, int value, String... tags) {
         send(String.format("%s%s:%d|h%s", prefix, aspect, value, tagString(tags)));
-    }
-
-    /**
-     * Records a value for the specified named histogram.
-     * 
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     */
-    @Override
-    public void recordHistogramValue(String aspect, int value) {
-        send(String.format("%s%s:%d|h", prefix, aspect, value));
     }
 
     /**
      * Convenience method equivalent to {@link #recordHistogramValue(String, int, String[])}. 
      */
     @Override
-    public void histogram(String aspect, int value, String[] tags) {
+    public void histogram(String aspect, int value, String... tags) {
         recordHistogramValue(aspect, value, tags);
-    }
-
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, int)}. 
-     */
-    @Override
-    public void histogram(String aspect, int value) {
-        recordHistogramValue(aspect, value);
     }
 
     private void send(final String message) {

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -37,19 +37,7 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void count(String aspect, int delta, String[] tags);
-
-    /**
-     * Adjusts the specified counter by a given delta.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to adjust
-     * @param delta
-     *     the amount to adjust the counter by
-     */
-    void count(String aspect, int delta);
+    void count(String aspect, int delta, String... tags);
 
     /**
      * Increments the specified counter by one.
@@ -63,27 +51,12 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void incrementCounter(String aspect, String[] tags);
-
-    /**
-     * Increments the specified counter by one.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to increment
-     */
-    void incrementCounter(String aspect);
+    void incrementCounter(String aspect, String... tags);
 
     /**
      * Convenience method equivalent to {@link #incrementCounter(String, String[])}.
      */
-    void increment(String aspect, String[] tags);
-
-    /**
-     * Convenience method equivalent to {@link #incrementCounter(String)}.
-     */
-    void increment(String aspect);
+    void increment(String aspect, String... tags);
 
     /**
      * Decrements the specified counter by one.
@@ -97,27 +70,12 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void decrementCounter(String aspect, String[] tags);
-
-    /**
-     * Decrements the specified counter by one.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the counter to decrement
-     */
-    void decrementCounter(String aspect);
-
-    /**
-     * Convenience method equivalent to {@link #decrementCounter(String)}.
-     */
-    void decrement(String aspect);
+    void decrementCounter(String aspect, String... tags);
 
     /**
      * Convenience method equivalent to {@link #decrementCounter(String, String[])}.
      */
-    void decrement(String aspect, String[] tags);
+    void decrement(String aspect, String... tags);
 
     /**
      * Records the latest fixed value for the specified named gauge.
@@ -131,31 +89,12 @@ public interface StatsDClient {
      * @param value
      *     the new reading of the gauge
      */
-    void recordGaugeValue(String aspect, double value, String[] tags);
-
-    /**
-     * Records the latest fixed value for the specified named gauge.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     */
-    void recordGaugeValue(String aspect, double value);
-
+    void recordGaugeValue(String aspect, double value, String... tags);
 
     /**
      * Convenience method equivalent to {@link #recordGaugeValue(String, double, String[])}.
      */
-    void gauge(String aspect, double value, String[] tags);
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, double)}.
-     */
-    void gauge(String aspect, double value);
-
+    void gauge(String aspect, double value, String... tags);
 
     /**
      * Records the latest fixed value for the specified named gauge.
@@ -169,30 +108,12 @@ public interface StatsDClient {
      * @param value
      *     the new reading of the gauge
      */
-    void recordGaugeValue(String aspect, int value, String[] tags);
-
-    /**
-     * Records the latest fixed value for the specified named gauge.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
-     */
-    void recordGaugeValue(String aspect, int value);
-
+    void recordGaugeValue(String aspect, int value, String... tags);
 
     /**
      * Convenience method equivalent to {@link #recordGaugeValue(String, int, String[])}.
      */
-    void gauge(String aspect, int value, String[] tags);
-
-    /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, int)}.
-     */
-    void gauge(String aspect, int value);
+    void gauge(String aspect, int value, String... tags);
 
     /**
      * Records an execution time in milliseconds for the specified named operation.
@@ -208,29 +129,12 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void recordExecutionTime(String aspect, int timeInMs, String[] tags);
+    void recordExecutionTime(String aspect, long timeInMs, String... tags);
 
     /**
-     * Records an execution time in milliseconds for the specified named operation.
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the timed operation
-     * @param timeInMs
-     *     the time in milliseconds
+     * Convenience method equivalent to {@link #recordExecutionTime(String, long, String[])}.
      */
-    void recordExecutionTime(String aspect, int timeInMs);
-
-    /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, int, String[])}.
-     */
-    void time(String aspect, int value, String[] tags);
-
-    /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, int)}.
-     */
-    void time(String aspect, int value);
+    void time(String aspect, long value, String... tags);
 
     /**
      * Records a value for the specified named histogram.
@@ -246,31 +150,12 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void recordHistogramValue(String aspect, double value, String[] tags);
-
-    /**
-     * Records a value for the specified named histogram.
-     *
-     * <p>This method is a DataDog extension, and may not work with other servers.</p>
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     */
-    void recordHistogramValue(String aspect, double value);
+    void recordHistogramValue(String aspect, double value, String... tags);
 
     /**
      * Convenience method equivalent to {@link #recordHistogramValue(String, double, String[])}.
      */
-    void histogram(String aspect, double value, String[] tags);
-
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, double)}.
-     */
-    void histogram(String aspect, double value);
+    void histogram(String aspect, double value, String... tags);
 
     /**
      * Records a value for the specified named histogram.
@@ -286,29 +171,11 @@ public interface StatsDClient {
      * @param tags
      *     array of tags to be added to the data
      */
-    void recordHistogramValue(String aspect, int value, String[] tags);
-
-    /**
-     * Records a value for the specified named histogram.
-     *
-     * <p>This method is a DataDog extension, and may not work with other servers.</p>
-     *
-     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     *
-     * @param aspect
-     *     the name of the histogram
-     * @param value
-     *     the value to be incorporated in the histogram
-     */
-    void recordHistogramValue(String aspect, int value);
+    void recordHistogramValue(String aspect, int value, String... tags);
 
     /**
      * Convenience method equivalent to {@link #recordHistogramValue(String, int, String[])}.
      */
-    void histogram(String aspect, int value, String[] tags);
+    void histogram(String aspect, int value, String... tags);
 
-    /**
-     * Convenience method equivalent to {@link #recordHistogramValue(String, int)}.
-     */
-    void histogram(String aspect, int value);
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -46,7 +46,7 @@ public class NonBlockingStatsDClientTest {
     sends_counter_value_to_statsd_with_empty_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.count("mycount", 24, new String[]{});
+        client.count("mycount", 24);
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c"));
@@ -56,7 +56,7 @@ public class NonBlockingStatsDClientTest {
     sends_counter_value_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.count("mycount", 24, new String[]{"foo:bar","baz"});
+        client.count("mycount", 24, "foo:bar","baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c|#baz,foo:bar"));
@@ -76,7 +76,7 @@ public class NonBlockingStatsDClientTest {
     sends_counter_increment_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.incrementCounter("myinc", new String[]{"foo:bar","baz"});
+        client.incrementCounter("myinc", "foo:bar","baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.myinc:1|c|#baz,foo:bar"));
@@ -96,7 +96,7 @@ public class NonBlockingStatsDClientTest {
     sends_counter_decrement_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.decrementCounter("mydec", new String[]{"foo:bar", "baz"});
+        client.decrementCounter("mydec", "foo:bar", "baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mydec:-1|c|#baz,foo:bar"));
@@ -146,7 +146,7 @@ public class NonBlockingStatsDClientTest {
     sends_gauge_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.recordGaugeValue("mygauge", 423, new String[]{"foo:bar","baz"});
+        client.recordGaugeValue("mygauge", 423, "foo:bar","baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:423|g|#baz,foo:bar"));
@@ -156,7 +156,7 @@ public class NonBlockingStatsDClientTest {
     sends_double_gauge_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.recordGaugeValue("mygauge", 0.423, new String[]{"foo:bar","baz"});
+        client.recordGaugeValue("mygauge", 0.423, "foo:bar","baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:0.423|g|#baz,foo:bar"));
@@ -186,7 +186,7 @@ public class NonBlockingStatsDClientTest {
     sends_histogram_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
 
-        client.recordHistogramValue("myhistogram", 423, new String[]{"foo:bar","baz"});
+        client.recordHistogramValue("myhistogram", 423, "foo:bar","baz");
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("my.prefix.myhistogram:423|h|#baz,foo:bar"));
@@ -196,7 +196,7 @@ public class NonBlockingStatsDClientTest {
     sends_double_histogram_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
 
-        client.recordHistogramValue("myhistogram", 0.423, new String[]{"foo:bar","baz"});
+        client.recordHistogramValue("myhistogram", 0.423, "foo:bar","baz");
         server.waitForMessage();
 
         assertThat(server.messagesReceived(), contains("my.prefix.myhistogram:0.423|h|#baz,foo:bar"));
@@ -216,7 +216,7 @@ public class NonBlockingStatsDClientTest {
     sends_timer_to_statsd_with_tags() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.recordExecutionTime("mytime", 123, new String[]{"foo:bar","baz"});
+        client.recordExecutionTime("mytime", 123, "foo:bar","baz");
         server.waitForMessage();
         
         assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|#baz,foo:bar"));


### PR DESCRIPTION
Cause for replacing String[] to String...

``` java
// More readable, simplify. With backwards compatibility
statsd.count("mycount", 24, new String[]{"foo:bar","baz"});
statsd.count("mycount", 24, "foo:bar","baz");
```

Cause for replacing int to long in time():

``` java
// Timestamp in java is always long. Use old api we must cast to int:
long started = System.currentTimeMillis(); // or System.nanoTime(), or Data#getTime();
foo();
long end = System.currentTimeMillis() - started;
statsd.time("requests.show_tables", (int) end);

// Now we pass timeout without casting: 
statsd.time("requests.show_tables", end);

// And backwards compatibility: casting without lose precision
int timeout = 10
statsd.time("requests.show_tables", timeout);
```
