### PR TITLE
NonBlockingStatsDClient as a daemon thread.

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -59,6 +59,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         @Override public Thread newThread(Runnable r) {
             Thread result = delegate.newThread(r);
             result.setName("StatsD-" + result.getName());
+            result.setDaemon(true);
             return result;
         }
     });


### PR DESCRIPTION
Simplify life-cycle management of NonBlockingStatsDClient by running send() in a daemon thread.
