### PR TITLE
performance improvements: squash messages, and NIO

### DIFF
--- a/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
+++ b/src/test/java/com/timgroup/statsd/DummyStatsDServer.java
@@ -1,0 +1,54 @@
+
+package com.timgroup.statsd;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+final class DummyStatsDServer {
+    private final List<String> messagesReceived = new ArrayList<String>();
+    private final DatagramSocket server;
+
+    public DummyStatsDServer(int port) throws SocketException {
+        server = new DatagramSocket(port);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while(!server.isClosed()) {
+                    try {
+                        final DatagramPacket packet = new DatagramPacket(new byte[1500], 1500);
+                        server.receive(packet);
+                        for(String msg : new String(packet.getData()).split("\n")) {
+                            messagesReceived.add(msg.trim());
+                        }
+                    } catch (IOException e) {
+                    }
+                }
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public void waitForMessage() {
+        while (messagesReceived.isEmpty()) {
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+
+    public List<String> messagesReceived() {
+        return new ArrayList<String>(messagesReceived);
+    }
+
+    public void close() {
+        server.close();
+    }
+
+}

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientPerfTest.java
@@ -1,0 +1,59 @@
+package com.timgroup.statsd;
+
+
+import java.net.SocketException;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class NonBlockingStatsDClientPerfTest {
+
+
+    private static final int STATSD_SERVER_PORT = 17255;
+    private static final Random RAND = new Random();
+    private final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT);
+    private final ExecutorService executor = Executors.newFixedThreadPool(20);
+    private DummyStatsDServer server;
+
+    @Before
+    public void start() throws SocketException {
+        server = new DummyStatsDServer(STATSD_SERVER_PORT);
+    }
+
+    @After
+    public void stop() throws Exception {
+        client.stop();
+        server.close();
+    }
+
+    @Test(timeout=30000)
+    public void perf_test() throws Exception {
+
+        int testSize = 10000;
+        for(int i = 0; i < testSize; ++i) {
+            executor.submit(new Runnable() {
+                public void run() {
+                    client.count("mycount", RAND.nextInt());
+                }
+            });
+
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(20, TimeUnit.SECONDS);
+
+        for(int i = 0; i < 20000 && server.messagesReceived().size() < testSize; i += 50) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {}
+        }
+
+        assertEquals(testSize, server.messagesReceived().size());
+    }
+}

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -1,13 +1,10 @@
 package com.timgroup.statsd;
 
+import java.net.SocketException;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.SocketException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,105 +14,112 @@ public class NonBlockingStatsDClientTest {
 
     private static final int STATSD_SERVER_PORT = 17254;
     private final NonBlockingStatsDClient client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT);
+    private DummyStatsDServer server;
+
+    @Before
+    public void start() throws SocketException {
+        server = new DummyStatsDServer(STATSD_SERVER_PORT);
+    }
 
     @After
     public void stop() throws Exception {
         client.stop();
+        server.close();
     }
 
     @Test(timeout=5000L) public void
     sends_counter_value_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.count("mycount", 24);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_value_to_statsd_with_null_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.count("mycount", 24, (java.lang.String[]) null);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_value_to_statsd_with_empty_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.count("mycount", 24);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_value_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.count("mycount", 24, "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mycount:24|c|#baz,foo:bar"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_increment_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.incrementCounter("myinc");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.myinc:1|c"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_increment_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.incrementCounter("myinc", "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.myinc:1|c|#baz,foo:bar"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_decrement_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.decrementCounter("mydec");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mydec:-1|c"));
     }
 
     @Test(timeout=5000L) public void
     sends_counter_decrement_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.decrementCounter("mydec", "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mydec:-1|c|#baz,foo:bar"));
     }
 
     @Test(timeout=5000L) public void
     sends_gauge_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordGaugeValue("mygauge", 423);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:423|g"));
     }
 
     @Test(timeout=5000L) public void
     sends_large_double_gauge_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordGaugeValue("mygauge", 123456789012345.67890);
         server.waitForMessage();
@@ -125,7 +129,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_exact_double_gauge_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordGaugeValue("mygauge", 123.45678901234567890);
         server.waitForMessage();
@@ -135,37 +139,37 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_double_gauge_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordGaugeValue("mygauge", 0.423);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:0.423|g"));
     }
 
     @Test(timeout=5000L) public void
     sends_gauge_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordGaugeValue("mygauge", 423, "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:423|g|#baz,foo:bar"));
     }
 
     @Test(timeout=5000L) public void
     sends_double_gauge_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordGaugeValue("mygauge", 0.423, "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mygauge:0.423|g|#baz,foo:bar"));
     }
 
     @Test(timeout=5000L) public void
     sends_histogram_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordHistogramValue("myhistogram", 423);
         server.waitForMessage();
@@ -175,7 +179,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_double_histogram_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordHistogramValue("myhistogram", 0.423);
         server.waitForMessage();
@@ -185,7 +189,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_histogram_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordHistogramValue("myhistogram", 423, "foo:bar", "baz");
         server.waitForMessage();
@@ -195,7 +199,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_double_histogram_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
         client.recordHistogramValue("myhistogram", 0.423, "foo:bar", "baz");
         server.waitForMessage();
@@ -205,11 +209,11 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_timer_to_statsd() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordExecutionTime("mytime", 123);
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mytime:0.123|h"));
     }
 
@@ -226,7 +230,7 @@ public class NonBlockingStatsDClientTest {
         Locale.setDefault(Locale.GERMANY);
 
         try {
-            final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
 
             client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
             server.waitForMessage();
@@ -241,18 +245,18 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_timer_to_statsd_with_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
-        
+
+
         client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
         server.waitForMessage();
-        
+
         assertThat(server.messagesReceived(), contains("my.prefix.mytime:0.123|h|#baz,foo:bar"));
     }
 
 
     @Test(timeout=5000L) public void
     sends_gauge_mixed_tags() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, new String[] {"instance:foo", "app:bar"});
         empty_prefix_client.gauge("value", 423, "baz");
         server.waitForMessage();
@@ -262,7 +266,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_gauge_constant_tags_only() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, new String[] {"instance:foo", "app:bar"});
         empty_prefix_client.gauge("value", 423);
         server.waitForMessage();
@@ -272,7 +276,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_gauge_empty_prefix() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
         final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("", "localhost", STATSD_SERVER_PORT);
         empty_prefix_client.gauge("top.level.value", 423);
         server.waitForMessage();
@@ -282,7 +286,7 @@ public class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_gauge_null_prefix() throws Exception {
-        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
         final NonBlockingStatsDClient null_prefix_client = new NonBlockingStatsDClient(null, "localhost", STATSD_SERVER_PORT);
         null_prefix_client.gauge("top.level.value", 423);
         server.waitForMessage();
@@ -290,33 +294,4 @@ public class NonBlockingStatsDClientTest {
         assertThat(server.messagesReceived(), contains("top.level.value:423|g"));
     }
 
-    private static final class DummyStatsDServer {
-        private final List<String> messagesReceived = new ArrayList<String>();
-        private final DatagramSocket server;
-
-        public DummyStatsDServer(int port) throws SocketException {
-            server = new DatagramSocket(port);
-            new Thread(new Runnable() {
-                @Override public void run() {
-                    try {
-                        final DatagramPacket packet = new DatagramPacket(new byte[256], 256);
-                        server.receive(packet);
-                        messagesReceived.add(new String(packet.getData()).trim());
-                        server.close();
-                    } catch (Exception e) { }
-                }
-            }).start();
-        }
-        
-        public void waitForMessage() {
-            while (messagesReceived.isEmpty()) {
-                try {
-                    Thread.sleep(50L);
-                } catch (InterruptedException e) {}}
-        }
-        
-        public List<String> messagesReceived() {
-            return new ArrayList<String>(messagesReceived);
-        }
-    }
 }


### PR DESCRIPTION
```
 - fit as many messages (that are in the queue) into the MTU as possible.
 - convert to NIO.
```

In addition to any NIO improvements,
     this will offer a performance improvement when the incoming message rate per the time it takes to call blockingSend() goes above one.
