### PR TITLE
restores "recordExecutionTime" compatibility with vanilla statsd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 build
 *.iml
+/target/

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -374,7 +374,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      */
     @Override
     public void recordExecutionTime(String aspect, long timeInMs, String... tags) {
-        recordHistogramValue(aspect, (timeInMs * 0.001), tags);
+        send(String.format("%s%s:%d|ms%s", prefix, aspect, timeInMs, tagString(tags)));
     }
 
     /**

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -214,7 +214,7 @@ public class NonBlockingStatsDClientTest {
         client.recordExecutionTime("mytime", 123);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mytime:0.123|h"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms"));
     }
 
     /**
@@ -235,7 +235,7 @@ public class NonBlockingStatsDClientTest {
             client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
             server.waitForMessage();
 
-            assertThat(server.messagesReceived(), contains("my.prefix.mytime:0.123|h|#baz,foo:bar"));
+            assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|#baz,foo:bar"));
         } finally {
             // reset the default Locale in case changing it has side-effects
             Locale.setDefault(originalDefaultLocale);
@@ -250,7 +250,7 @@ public class NonBlockingStatsDClientTest {
         client.recordExecutionTime("mytime", 123, "foo:bar", "baz");
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mytime:0.123|h|#baz,foo:bar"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|#baz,foo:bar"));
     }
 
 


### PR DESCRIPTION
 references:
- statsd documentation – https://github.com/etsy/statsd/blob/master/docs/metric_types.md
- breakage from commit dcae  – https://github.com/indeedeng/java-dogstatsd-client/commit/dcaed45c36ef74ba370d806647a4a06b173a9566#commitcomment-5832637
