### PR TITLE
Service check support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,3 @@ public class Foo {
   }
 }
 ```
-

--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -3,7 +3,7 @@ package com.timgroup.statsd;
 /**
  * A No-Op StatsDClient, which can be substituted in when metrics are not
  * required.
- * 
+ *
  * @author Tom Denley
  *
  */
@@ -25,4 +25,6 @@ public final class NoOpStatsDClient implements StatsDClient {
     @Override public void recordHistogramValue(String aspect, long value, String... tags) { }
     @Override public void histogram(String aspect, long value, String... tags) { }
     @Override public void recordEvent(final Event event, final String... tags) { }
+    @Override public void recordServiceCheckRun(ServiceCheck sc) { }
+    @Override public void serviceCheck(ServiceCheck sc) { }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -491,6 +491,44 @@ public final class NonBlockingStatsDClient implements StatsDClient {
                 title.length(), text.length(), title, text, eventMap(event), tagString(tags)));
     }
 
+    /**
+     * Records a run status for the specified named service check.
+     *
+     * <p>This method is a DataDog extension, and may not work with other servers.</p>
+     *
+     * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
+     *
+     * @param sc
+     *     the service check object
+     */
+    @Override public void recordServiceCheckRun(ServiceCheck sc) {
+        send(toStatsDString(sc));
+    }
+    
+    private String toStatsDString(ServiceCheck sc) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("_sc|%s|%d", sc.getName(), sc.getStatus()));
+        if (sc.getTimestamp() > 0) {
+            sb.append(String.format("|d:%d", sc.getTimestamp()));
+        }
+        if (sc.getHostname() != null) {
+            sb.append(String.format("|h:%s", sc.getHostname()));
+        }
+        sb.append(tagString(sc.getTags()));
+        if (sc.getMessage() != null) {
+            sb.append(String.format("|m:%s", sc.getEscapedMessage()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Convenience method equivalent to {@link #recordServiceCheckRun(ServiceCheck sc)}.
+     */
+    @Override
+    public void serviceCheck(ServiceCheck sc) {
+        recordServiceCheckRun(sc);
+    }
+
     private void send(String message) {
         queue.offer(message);
     }

--- a/src/main/java/com/timgroup/statsd/ServiceCheck.java
+++ b/src/main/java/com/timgroup/statsd/ServiceCheck.java
@@ -1,0 +1,135 @@
+package com.timgroup.statsd;
+
+/**
+ * A service check model, which is used to format a service check message
+ * sent to the datadog agent
+ */
+public class ServiceCheck {
+    public static final int OK = 0;
+    public static final int WARNING = 1;
+    public static final int CRITICAL = 2;
+    public static final int UNKNOWN = 3;
+
+    private String name, hostname, message;
+
+    private int status, checkRunId, timestamp;
+
+    private String[] tags;
+
+    /**
+     */
+    public ServiceCheck() {
+    }
+
+    /**
+     * @param name
+     * @param status
+     */
+    public ServiceCheck(String name, int status) {
+        this(name, status, null, null, null);
+    }
+
+    public ServiceCheck(String name, int status, String message, String[] tags) {
+        this(name, status, message, null, tags);
+    }
+
+    public ServiceCheck(String name, int status, String message, String hostname, String[] tags) {
+        this.name = name;
+        this.status = status;
+        this.message = message;
+        this.hostname = hostname;
+        this.tags = tags;
+    }
+
+    /**
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return
+     */
+    public int getStatus() {
+        return status;
+    }
+
+    /**
+     * @param status
+     */
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    /**
+     * @return
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @return
+     */
+    public String getEscapedMessage() {
+        return message.replace("\n", "\\n").replace("m:", "m\\:");
+    }
+
+    /**
+     *
+     * @param message
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * @return
+     */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /**
+     * @param hostname
+     */
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    /**
+     * @return
+     */
+    public int getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * @param timestamp
+     */
+    public void setTimestamp(int timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @return
+     */
+    public String[] getTags() {
+        return tags;
+    }
+
+    /**
+     * @param tags
+     */
+    public void setTags(String... tags) {
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -193,4 +193,18 @@ public interface StatsDClient {
      * @see <a href="http://docs.datadoghq.com/guides/dogstatsd/#events-1">http://docs.datadoghq.com/guides/dogstatsd/#events-1</a>
      */
     void recordEvent(Event event, String... tags);
+
+    /**
+     * Records a run status for the specified named service check.
+     *
+     * @param sc
+     *     the service check object
+     */
+    void recordServiceCheckRun(ServiceCheck sc);
+
+    /**
+     * Convenience method equivalent to {@link #recordServiceCheckRun(ServiceCheck sc)}.
+     */
+    void serviceCheck(ServiceCheck sc);
+
 }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -376,4 +376,17 @@ public class NonBlockingStatsDClientTest {
 
         assertThat(server.messagesReceived(), contains("_e{6,5}:title1|text1|d:1234567|h:host1|k:key1|p:low|t:error|#baz,foo:bar"));
     }
+
+    @Test(timeout=5000L) public void
+    sends_service_check() throws Exception {
+        String[] tags = {"key1:val1", "key2:val2"};
+        ServiceCheck sc = new ServiceCheck("my_check.name", ServiceCheck.WARNING, "♬ †øU \n†øU ¥ºu|m: T0µ ♪", "i-abcd1234", tags);
+        sc.setTimestamp(1420740000);
+
+        client.serviceCheck(sc);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s",
+                "♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")));
+    }
 }


### PR DESCRIPTION
Hello Indeed,

This PR brings Service Check support to Java Dogstatsd Client.

Usage:

```java
import com.timgroup.statsd.StatsDClient;
import com.timgroup.statsd.NonBlockingStatsDClient;

public class Foo {

  private static final StatsDClient statsd = new NonBlockingStatsDClient(
    "my.prefix",                          /* prefix to any stats; may be null or empty string */
    "statsd-host",                        /* common case: localhost */
    8125,                                 /* port */
    new String[] {"tag:value"}            /* DataDog extension: Constant tags, always applied */
  );

  public static final void main(String[] args) {
    ServiceCheck sc = new ServiceCheck("my.check.name", ServiceCheck.OK);
    statsd.serviceCheck(sc); /* Datadog extension: send service check status */
  }
}
```

Custom checks are then avaiable from 'Monitors' -> 'Custom check' section.
![screenshot 2015-04-28 11 04 12](https://cloud.githubusercontent.com/assets/5708089/7372757/9130cc48-ed96-11e4-995b-33c4f6fe9967.png)

