### PR TITLE
Sets NaN symbol format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -5,6 +5,8 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.charset.Charset;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
@@ -65,6 +67,12 @@ public final class NonBlockingStatsDClient implements StatsDClient {
             NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
             numberFormatter.setGroupingUsed(false);
             numberFormatter.setMaximumFractionDigits(6);
+
+            // we need to specify a value for Double.NaN that is recognized by dogStatsD
+            DecimalFormatSymbols symbols = ((DecimalFormat) numberFormatter).getDecimalFormatSymbols();
+            symbols.setNaN("NaN");
+            ((DecimalFormat) numberFormatter).setDecimalFormatSymbols(symbols);
+
             return numberFormatter;
         }
     };

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -3,13 +3,16 @@ package com.timgroup.statsd;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import java.net.SocketException;
+import java.text.NumberFormat;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NonBlockingStatsDClientTest {
 
@@ -399,5 +402,22 @@ public class NonBlockingStatsDClientTest {
 
         assertThat(server.messagesReceived(), contains(String.format("_sc|my_check.name|1|d:1420740000|h:i-abcd1234|#key2:val2,key1:val1|m:%s",
                 outputMessage)));
+    }
+
+    @Test(timeout=5000L) public void
+    number_formatters_handles_nan() throws Exception {
+        ThreadLocal<NumberFormat> NUMBER_FORMATTERS = Whitebox.getInternalState(NonBlockingStatsDClient.class, "NUMBER_FORMATTERS");
+        String formattedValue = NUMBER_FORMATTERS.get().format(Double.NaN);
+
+        assertTrue(formattedValue.equals("NaN"));
+    }
+
+    @Test(timeout=5000L) public void
+    sends_nan_gauge_to_statsd() throws Exception {
+        client.recordGaugeValue("mygauge", Double.NaN);
+
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.mygauge:NaN|g"));
     }
 }


### PR DESCRIPTION
I've never contributed code to an open source project and the parts I've tried to modify are a little complicated.  Basically, when a metric returns Double.NaN and the formatter gets applied to it, we're getting the default symbol returned which ends up as a "?".  This ends up breaking dogStatsD parsing (their parser can handle a "NaN" or "nan" but not a "?"). 

I was a little confused where the specific type of NumberFormat was coming from and as it is late on Friday I didn't want to dig in too much further.  What I tried to do is, assuming that since we're probably almost always parsing Double type data (since we're working with metrics), cast the NumberFormat to the DecimalFormat type so that I could set the preferred NaN symbol.  I wrote two tests that were red and now are green.  Not sure if you guys are going to be down with my adding Powermock to the POM for just one test.  Also not sure if my assumption that we're always working with the DecimalFormat object is correct.  I almost changed the NUMBER_FORMATTERS type to be ThreadLocal<DecimalFormat> but decided I'd start small.  Please let me know what you think and if I should make any changes.  Hopefully this is helpful.