### PR TITLE
Wiring in a queueSize constructor parameter for NonBlockingStatsDClient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ public class Foo {
     "my.prefix",                          /* prefix to any stats; may be null or empty string */
     "statsd-host",                        /* common case: localhost */
     8125,                                 /* port */
+    10000,                                /* Maximum queue size before blocking, so that we prevent OOM */
     new String[] {"tag:value"}            /* DataDog extension: Constant tags, always applied */
   );
 

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -258,7 +258,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout=5000L) public void
     sends_gauge_mixed_tags() throws Exception {
 
-        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, new String[] {"instance:foo", "app:bar"});
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, "instance:foo", "app:bar");
         empty_prefix_client.gauge("value", 423, "baz");
         server.waitForMessage();
 
@@ -268,7 +268,7 @@ public class NonBlockingStatsDClientTest {
     @Test(timeout=5000L) public void
     sends_gauge_constant_tags_only() throws Exception {
 
-        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, new String[] {"instance:foo", "app:bar"});
+        final NonBlockingStatsDClient empty_prefix_client = new NonBlockingStatsDClient("my.prefix", "localhost", STATSD_SERVER_PORT, Integer.MAX_VALUE, "instance:foo", "app:bar");
         empty_prefix_client.gauge("value", 423);
         server.waitForMessage();
 


### PR DESCRIPTION
With UDP, it's far unlikely that you'll OOM, but with enough concurrency it is possible. Better to set a high limit and be safe than have a JVM crash.

Also, if the developer wants blocking or near-blocking behavior, they just have to use 0 or a lower number respectively.